### PR TITLE
fix: change the foreign key names to big camel case

### DIFF
--- a/models/like.js
+++ b/models/like.js
@@ -3,8 +3,8 @@ module.exports = (sequelize, DataTypes) => {
   const Like = sequelize.define('Like', {
   }, {});
   Like.associate = function(models) {
-    Like.belongsTo(models.Tweet, {foreignKey: 'tweetId'})
-    Like.belongsTo(models.User, {foreignKey: 'userId'})
+    Like.belongsTo(models.Tweet, {foreignKey: 'TweetId'})
+    Like.belongsTo(models.User, {foreignKey: 'UserId'})
   };
   Like.init({
     UserId: DataTypes.INTEGER,

--- a/models/reply.js
+++ b/models/reply.js
@@ -3,13 +3,13 @@ module.exports = (sequelize, DataTypes) => {
   const Reply = sequelize.define('Reply', {
   }, {})
   Reply.associate = function(models) {
-    Reply.belongsTo(models.Tweet, { foreignKey: 'tweetId'})
-    Reply.belongsTo(models.User, { foreignKey: 'userId'})
+    Reply.belongsTo(models.Tweet, { foreignKey: 'TweetId'})
+    Reply.belongsTo(models.User, { foreignKey: 'UserId'})
   }
   Reply.init({
     comment: DataTypes.TEXT,
-    userId: DataTypes.INTEGER,
-    tweetId: DataTypes.INTEGER
+    UserId: DataTypes.INTEGER,
+    TweetId: DataTypes.INTEGER
   },
   {
     sequelize,

--- a/models/tweet.js
+++ b/models/tweet.js
@@ -3,13 +3,13 @@ module.exports = (sequelize, DataTypes) => {
   const Tweet = sequelize.define('Tweet', {
   }, {});
   Tweet.associate = function(models) {
-    Tweet.hasMany(models.Like, {foreignKey: 'tweetId'})
-    Tweet.hasMany(models.Reply, {foreignKey: 'tweetId'})
-    Tweet.belongsTo(models.User, {foreignKey: 'userId'})
+    Tweet.hasMany(models.Like, {foreignKey: 'TweetId'})
+    Tweet.hasMany(models.Reply, {foreignKey: 'TweetId'})
+    Tweet.belongsTo(models.User, {foreignKey: 'UserId'})
   };
   Tweet.init({
     description: DataTypes.TEXT,
-    userId: DataTypes.INTEGER
+    UserId: DataTypes.INTEGER
   }, {
     sequelize,
     modelName: 'Tweet',

--- a/models/user.js
+++ b/models/user.js
@@ -3,9 +3,9 @@ module.exports = (sequelize, DataTypes) => {
   const User = sequelize.define('User', {
   }, {})
   User.associate = function(models) {
-    User.hasMany(models.Like, { foreignKey: 'userId' })
-    User.hasMany(models.Reply, { foreignKey: 'userId' })
-    User.hasMany(models.Tweet, { foreignKey: 'userId' })
+    User.hasMany(models.Like, { foreignKey: 'UserId' })
+    User.hasMany(models.Reply, { foreignKey: 'UserId' })
+    User.hasMany(models.Tweet, { foreignKey: 'UserId' })
     User.belongsToMany(User, {
         through: models.Followship,
         foreignKey: 'followingId',


### PR DESCRIPTION
因為測試檔規定外鍵名稱需用大駝峰命名，所以變更名稱。
唯 followship 表單的關聯較特殊，所以維持其外鍵名稱維持小駝峰命名。